### PR TITLE
Clarify README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ gem 'blazer'
 Run:
 
 ```sh
+rails bundle install
 rails g blazer:install
 rake db:migrate
 ```


### PR DESCRIPTION
I added the specification to run 'bundle install' before running 'rails g blazer:install'

Not a big change, but I typically copy and paste documentation installation instructions line by line, and I got an error the first time I tried to install the gem since there was no instruction to run 'bundle install'